### PR TITLE
Updated Security

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -23,11 +23,11 @@ spec:
           env:
           - name: SERVER_HOST
             value: 0.0.0.0
-          - name: SLACK_VERIFICATION_TOKEN
+          - name: SLACK_SIGNING_SECRET
             valueFrom:
               secretKeyRef:
                 name: slackauth
-                key: SLACK_VERIFICATION_TOKEN
+                key: SLACK_SIGNING_SECRET
           - name: SLACK_AUTHENTICATION_TOKEN
             valueFrom:
               secretKeyRef:

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -1,0 +1,75 @@
+package slack
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	version                     = "v0"
+	slackRequestTimestampHeader = "X-Slack-Request-Timestamp"
+	slackSignatureHeader        = "X-Slack-Signature"
+)
+
+// VerifyWebHook verifies the request signature.
+// See https://api.slack.com/docs/verifying-requests-from-slack.
+func VerifyWebHook(r *http.Request, slackSigningSecret string) (bool, error) {
+	timeStamp := r.Header.Get(slackRequestTimestampHeader)
+	slackSignature := r.Header.Get(slackSignatureHeader)
+
+	t, err := strconv.ParseInt(timeStamp, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("strconv.ParseInt(%s): %v", timeStamp, err)
+	}
+
+	if ageOk, age := checkTimestamp(t); !ageOk {
+		return false, fmt.Errorf("checkTimestamp(%v): %v %v", t, ageOk, age)
+	}
+
+	if timeStamp == "" || slackSignature == "" {
+		return false, fmt.Errorf("either timeStamp or signature headers were blank")
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return false, fmt.Errorf("ioutil.ReadAll(%v): %v", r.Body, err)
+	}
+
+	// Reset the body so other calls won't fail.
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	baseString := fmt.Sprintf("%s:%s:%s", version, timeStamp, body)
+
+	signature := getSignature([]byte(baseString), []byte(slackSigningSecret))
+
+	trimmed := strings.TrimPrefix(slackSignature, fmt.Sprintf("%s=", version))
+	signatureInHeader, err := hex.DecodeString(trimmed)
+
+	if err != nil {
+		return false, fmt.Errorf("hex.DecodeString(%v): %v", trimmed, err)
+	}
+
+	return hmac.Equal(signature, signatureInHeader), nil
+}
+
+func getSignature(base []byte, secret []byte) []byte {
+	h := hmac.New(sha256.New, secret)
+	h.Write(base)
+
+	return h.Sum(nil)
+}
+
+// Arbitrarily trusting requests time stamped less than 5 minutes ago.
+func checkTimestamp(timeStamp int64) (bool, time.Duration) {
+	t := time.Since(time.Unix(timeStamp, 0))
+
+	return t.Minutes() <= 5, t
+}

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -1,0 +1,44 @@
+package slack
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSigningWithSecret(t *testing.T) {
+	type testCase struct {
+		name       string
+		signature  string
+		timeStamp  string
+		wantResult bool
+	}
+
+	secret := "talesfromthecrypt"
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	body := "somebody"
+	base := fmt.Sprintf("%s:%s:%s", version, ts, body)
+	correctSHA2Signature := fmt.Sprintf("%s=%s", version, hex.EncodeToString(getSignature([]byte(base), []byte(secret))))
+
+	tests := []testCase{
+		{name: "Good request", signature: correctSHA2Signature, timeStamp: ts, wantResult: true},
+		{name: "Bad signature", signature: "v0=146abde6763faeba19adc4d9fe4961668f4be11f7405a1c05b636f29312eac2e", timeStamp: ts, wantResult: false},
+		{name: "Old timestamp", signature: correctSHA2Signature, timeStamp: "12345", wantResult: false},
+	}
+
+	for _, tc := range tests {
+		rq := httptest.NewRequest("POST", "https://someurl.com", strings.NewReader("somebody"))
+		rq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		rq.Header.Add("X-Slack-Request-Timestamp", tc.timeStamp)
+		rq.Header.Add("X-Slack-Signature", tc.signature)
+
+		got, _ := VerifyWebHook(rq, secret)
+		if tc.wantResult != got {
+			t.Errorf("Test: %v - Wanted: %v but got: %v", tc.name, tc.wantResult, got)
+		}
+	}
+}


### PR DESCRIPTION
# Changelog

- Updated the webhook endpoint to use the signing token instead of deprecated verification token

Link: https://api.slack.com/authentication/verifying-requests-from-slack