### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,9 @@ on:
     types:
       - edited
       - created
+env:
+  GKE_CLUSTER: cs-eng-apps-europe-west3  
+  GKE_REGION: europe-west3
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -60,6 +63,8 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: [build] # Only run this workflow when "build" workflow succeeds
+    outputs:
+      docker_tag: ${{ steps.docker_meta.outputs.version }}
     steps:
     - uses: actions/checkout@v2
     - name: Docker meta
@@ -91,3 +96,42 @@ jobs:
         push: true
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: image_build
+    env:
+      DOCKER_TAG: ${{ needs.image_build.outputs.docker_tag }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: google-github-actions/setup-gcloud@master
+      with:
+        version: '290.0.1'
+        service_account_key: ${{ secrets.GKE_SA_KEY }}
+        project_id: ${{ secrets.GKE_PROJECT }}
+    - run: |-
+        gcloud container clusters get-credentials $GKE_CLUSTER --region $GKE_REGION
+    - name: Set up Kustomize
+      run: |-
+        curl -sfLo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v3.1.0/kustomize_3.1.0_linux_amd64
+        chmod u+x ./kustomize
+        export PATH=$PATH:$PWD
+    - name: Decrypt secrets
+      run: |-
+        ./scripts/decrypt
+    - name: Kustomize build
+      working-directory: ./manifests/staging
+      run: |-
+        kustomize edit set image containersol/jeeves=containersol/jeeves:$DOCKER_TAG
+        kustomize build > /dev/null
+    - name: Kustomize deploy staging
+      if: github.ref == 'refs/heads/master'
+      working-directory: ./manifests/staging
+      run: |-
+        kustomize edit set image containersol/jeeves=containersol/jeeves:$DOCKER_TAG
+        kustomize build | kubectl apply -f -
+    - name: Kustomize deploy production
+      working-directory: ./manifests/production
+      if: startsWith(github.ref, 'refs/tags')
+      run: |-
+        kustomize edit set image containersol/jeeves=containersol/jeeves:$DOCKER_TAG
+        kustomize build | kubectl apply -f -


### PR DESCRIPTION
Fixes  #16

* When building PR:
   * Build image, run kustomize build, exit
* When building master branch:
   * Same as above, but deploy in jeeves-test namespace on apps cluster
* When building a tag:
   *  Same as first, but deploy in jeeves namespaces on apps cluster
 
Uses docker_meta.outputs.version as the deployment tag.  